### PR TITLE
PRMT-4392

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.2-alpine
+FROM node:20-alpine
 
 # Install common Dojo scripts
 ENV DOJO_VERSION=0.10.2


### PR DESCRIPTION
- Updated the Dockerfile to pull from node:20-alpine (LTS), rather than node:18.2-alpine.