### PR TITLE
bump up node version to 22.5, fix non-buildable Dockerfile

### DIFF
--- a/Dojofile
+++ b/Dojofile
@@ -1,1 +1,1 @@
-DOJO_DOCKER_IMAGE="nhsdev/deductions-infra-dojo:22-d1e07974"
+DOJO_DOCKER_IMAGE="nhsdev/deductions-infra-dojo:24-47f9f50f"

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:22.5-alpine
 
 # Install common Dojo scripts
 ENV DOJO_VERSION=0.11.0
@@ -10,10 +10,7 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repos
   rm -r /tmp/dojo_git &&\
   echo 'dojo ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
 
-ENV AWS_CLI_VERSION=2.15.12 BOTO3_VERSION=1.34.23
-RUN apk add --no-cache make python3 py3-pip curl groff &&\
-    python3 -m ensurepip --upgrade &&\
-    python3 -m pip install awscli==${AWS_CLI_VERSION} boto3==${BOTO3_VERSION}
+RUN apk add --no-cache make python3 py3-pip curl groff aws-cli
 
 # Install sequelize postgress native dependencies
 RUN apk add --no-cache postgresql-dev g++ make

--- a/tasks
+++ b/tasks
@@ -2,7 +2,7 @@
 
 set -Eeuo pipefail
 
-DOCKER_OPS_VERSION="2.0.0"
+DOCKER_OPS_VERSION="2.0.1"
 DOCKER_OPS_FILE="ops/docker-ops-${DOCKER_OPS_VERSION}"
 AWS_REGION="eu-west-2"
 


### PR DESCRIPTION
- bump up node version to 22.5
- fix the current non-buildable Dockerfile
According to build history in gocd pipelne, the current Dockerfile in master branch was never built successfully. 
That is because the protection mechanism in PEP-668 prevents manipulation of Alpine's system-wide Python installation.
As the intention of `pip install` seems to be solely getting aws-cli, we will use the aws-cli from Alpine apk instead of installing it from pip.